### PR TITLE
Add packaging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@
 
 ## Installation
 
-Clone this repository and install locally:
+Install from PyPI:
+
+```bash
+pip install doors-dwa-client
+```
+
+Alternatively, install from source:
 
 ```bash
 git clone https://github.com/stefbo/doors-dwa-client.git

--- a/dwa_client/__init__.py
+++ b/dwa_client/__init__.py
@@ -1,4 +1,8 @@
+"""Top-level package for the DOORS DWA client library."""
+
 from dwa_client.client import DWAClient
 from dwa_client.resources import Folder, Guid, Document, DocumentObject
 
-__all__ = ["DWAClient", "Folder", "Guid", "Document", "DocumentObject"]
+__version__ = "0.1.0"
+
+__all__ = ["DWAClient", "Folder", "Guid", "Document", "DocumentObject", "__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "doors-dwa-client"
+version = "0.1.0"
+description = "Python client for IBM DOORS Classic Web Access and OSLC APIs"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [
+  {name = "Stefan Bolus", email = "stefan.bolus@gmx.de"}
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent"
+]
+dependencies = [
+    "requests",
+    "beautifulsoup4",
+    "lxml",
+    "rdflib",
+    "urllib3"
+]
+
+[project.urls]
+Homepage = "https://github.com/stefbo/doors-dwa-client"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["dwa_client*"]
+


### PR DESCRIPTION
## Summary
- add pyproject-based packaging metadata
- expose package version in `dwa_client.__init__`
- document installing via pip

## Testing
- `pip install -e .`
- `pip show doors-dwa-client`

------
https://chatgpt.com/codex/tasks/task_e_68488f4f9200832db74c326b9a1b5ad3